### PR TITLE
[FQ-62] Unit Create

### DIFF
--- a/app/controllers/api/v1/units_controller.rb
+++ b/app/controllers/api/v1/units_controller.rb
@@ -5,12 +5,30 @@ module Api
     class UnitsController < ApplicationController
       before_action :set_unit, only: [ :show ]
 
-      def show; end
+      def create
+        course = Course.find(params[:course_id])
+        authorize! :update, course
+        @unit = course.units.new(
+          unit_params.merge(position: course.units.maximum(:position).to_i + 1)
+        )
+
+        unless @unit.save
+          render json: { errors: @unit.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def show
+        authorize! :read, @unit
+      end
 
       private
 
       def set_unit
         @unit = Course.find(params[:course_id])&.units&.find(params[:id])
+      end
+
+      def unit_params
+        params.require(:unit).permit(:name, :description)
       end
     end
   end

--- a/app/models/abilities/teacher_ability.rb
+++ b/app/models/abilities/teacher_ability.rb
@@ -16,5 +16,9 @@ module Abilities
     def courses_policy
       @ability.can [ :read, :update ], Course, users: { id: @user.id }
     end
+
+    def units_policy
+      @ability.can [ :read ], Unit, course: { users: { id: @user.id } }
+    end
   end
 end

--- a/app/views/api/v1/units/create.jbuilder
+++ b/app/views/api/v1/units/create.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! @unit, partial: "unit", as: :unit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth"
       resources :courses, only: [ :show, :update ] do
-        resources :units, only: [ :show ]
+        resources :units, only: [ :show, :create ]
       end
     end
   end

--- a/spec/controllers/api/v1/units_controller_spec.rb
+++ b/spec/controllers/api/v1/units_controller_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::UnitsController, type: :controller do
+  let(:user) { create(:user, :teacher) }
+  let(:valid_attributes) { { name: 'My new Unit Rampla', description: 'Omg this is a new unit' } }
+  let(:invalid_attributes) { { name: '', description: '' } }
+
+  before do
+    auth_headers = user.create_new_auth_token
+    request.headers.merge!(auth_headers)
+  end
+
+  describe 'POST #create' do
+    context 'when user is authorized' do
+      let (:course) { user.selected_course }
+      context 'with valid params' do
+        before do
+          post :create, params: { course_id: course.id, unit: valid_attributes }
+        end
+
+        it 'creates a new Unit' do
+          expect(Unit.count).to eq(1)
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:success)
+        end
+      end
+      context 'with invalid params' do
+        before do
+          allow(controller).to receive(:authorize!).and_return(true)
+          post :create, params: { course_id: course.id, unit: invalid_attributes }
+        end
+
+        it 'does not create a new Unit' do
+          expect(Unit.count).to eq(0)
+        end
+
+        it 'returns http unprocessable entity' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'returns error messages' do
+          expect(JSON.parse(response.body)['errors']).to include(
+            "Name no puede estar en blanco", "Description no puede estar en blanco"
+          )
+        end
+      end
+    end
+    context 'when user is not authorized' do
+      let (:course) { create(:course) }
+      it 'raises CanCan::AccessDenied' do
+        expect {
+          post :create, params: { course_id: course.id, unit: valid_attributes }
+        }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+    context 'when course does not exist' do
+      before do
+        allow(controller).to receive(:authorize!).and_return(true)
+        post :create, params: { course_id: 0, unit: valid_attributes }
+      end
+
+      it 'returns http not found' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns error message' do
+        expect(JSON.parse(response.body)['errors']).to include("Couldn't find Course with 'id'=0")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces functionality to create units within a course, updates authorization policies, and adds the necessary routes and views to support this feature. The most important changes are grouped below by theme.

### New Unit Creation Feature:
* Added a `create` action in `app/controllers/api/v1/units_controller.rb` to allow creating a new unit within a course. This action includes position auto-calculation, authorization checks, and error handling.
* Added a `create.jbuilder` view to render the newly created unit using a partial.

### Authorization Updates:
* Updated the `TeacherAbility` model to include a `units_policy` method, granting teachers `read` access to units within their courses.

### Routing Changes:
* Updated `config/routes.rb` to include the `create` action for units under the `courses` resource.