### PR TITLE
[FQ-63] Unit Edit

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -4,6 +4,7 @@ module Api
   class ApplicationController < ::ApplicationController
     before_action :authenticate_api_v1_user!
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+    rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
 
     def current_user
       current_api_v1_user
@@ -13,6 +14,10 @@ module Api
 
     def record_not_found(exception)
       render json: { errors: [ exception.message ] }, status: :not_found
+    end
+
+    def record_invalid(exception)
+      render json: { errors: [ exception.message ] }, status: :unprocessable_entity
     end
   end
 end

--- a/app/controllers/api/v1/units_controller.rb
+++ b/app/controllers/api/v1/units_controller.rb
@@ -3,22 +3,27 @@
 module Api
   module V1
     class UnitsController < ApplicationController
-      before_action :set_unit, only: [ :show ]
+      before_action :set_unit, only: [ :show, :update ]
 
       def create
-        course = Course.find(params[:course_id])
-        authorize! :update, course
-        @unit = course.units.new(
-          unit_params.merge(position: course.units.maximum(:position).to_i + 1)
-        )
+        @course = Course.find(params[:course_id])
+        authorize! :update, @course
 
-        unless @unit.save
-          render json: { errors: @unit.errors.full_messages }, status: :unprocessable_entity
-        end
+        reorder_and_create(unit_params[:position].to_i)
       end
 
       def show
         authorize! :read, @unit
+      end
+
+      def update
+        authorize! :update, @unit
+
+        if unit_params[:position].blank? || unit_params[:position].to_i == @unit.position
+          return @unit.update!(unit_params)
+        end
+
+        reorder_and_update(unit_params[:position].to_i)
       end
 
       private
@@ -28,7 +33,35 @@ module Api
       end
 
       def unit_params
-        params.require(:unit).permit(:name, :description)
+        params.require(:unit).permit(:name, :description, :position)
+      end
+
+      def reorder_and_create(new_position)
+        ActiveRecord::Base.transaction do
+          @course.units
+            .where("position >= ?", new_position)
+            .update_all("position = position + 1")
+
+          @unit = @course.units.create!(unit_params)
+        end
+      end
+
+      def reorder_and_update(new_position)
+        old_position = @unit.position
+
+        ActiveRecord::Base.transaction do
+          if new_position > old_position
+            @unit.course.units
+              .where("position > ? AND position <= ?", old_position, new_position)
+              .update_all("position = position - 1")
+          elsif new_position < old_position
+            @unit.course.units
+              .where("position >= ? AND position < ?", new_position, old_position)
+              .update_all("position = position + 1")
+          end
+
+          @unit.update!(unit_params)
+        end
       end
     end
   end

--- a/app/models/abilities/teacher_ability.rb
+++ b/app/models/abilities/teacher_ability.rb
@@ -9,6 +9,7 @@ module Abilities
       @ability = ability
 
       courses_policy
+      units_policy
     end
 
     private
@@ -18,7 +19,7 @@ module Abilities
     end
 
     def units_policy
-      @ability.can [ :read ], Unit, course: { users: { id: @user.id } }
+      @ability.can [ :read, :update ], Unit, course: { users: { id: @user.id } }
     end
   end
 end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -6,6 +6,6 @@ class Unit < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
   validates :position, presence: true,
-    numericality: { only_integer: true, greater_than_or_equal_to: 0 },
+    numericality: { only_integer: true, greater_than_or_equal_to: 1 },
     uniqueness: { scope: :course_id, message: "debe ser único por curso" }
 end

--- a/app/views/api/v1/units/update.jbuilder
+++ b/app/views/api/v1/units/update.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.unit @unit, partial: "unit", as: :unit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth"
       resources :courses, only: [ :show, :update ] do
-        resources :units, only: [ :show, :create ]
+        resources :units, only: [ :show, :create, :update ]
       end
     end
   end

--- a/db/migrate/20250418144951_create_unit.rb
+++ b/db/migrate/20250418144951_create_unit.rb
@@ -4,7 +4,7 @@ class CreateUnit < ActiveRecord::Migration[8.0]
       t.string :name, null: false, default: ""
       t.string :description, null: false, default: ""
       t.references :course, null: false, foreign_key: true
-      t.integer :position, null: false, default: 0
+      t.integer :position, null: false, default: 1
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_18_144951) do
     t.string "name", default: "", null: false
     t.string "description", default: "", null: false
     t.bigint "course_id", null: false
-    t.integer "position", default: 0, null: false
+    t.integer "position", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_units_on_course_id"

--- a/db/seeds/units.rb
+++ b/db/seeds/units.rb
@@ -8,19 +8,19 @@ Unit.find_or_create_by!(
   name: 'Introducción a la programación',
   description: 'Introducción a la programación con Pascal, incluyendo variables, tipos de datos y estructuras de control.',
   course: p1_course,
-  position: 0,
+  position: 1,
 )
 Unit.find_or_create_by!(
   name: 'Estructuras de control',
   description: 'Estructuras de control en Pascal, incluyendo condicionales y bucles.',
   course: p1_course,
-  position: 1,
+  position: 2,
 )
 Unit.find_or_create_by!(
   name: 'Funciones y procedimientos',
   description: 'Funciones y procedimientos en Pascal, incluyendo parámetros y retorno de valores.',
   course: p1_course,
-  position: 2,
+  position: 3,
 )
 
 puts "Units seed executed successfully! :)"

--- a/spec/controllers/api/v1/units_controller_spec.rb
+++ b/spec/controllers/api/v1/units_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Api::V1::UnitsController, type: :controller do
 
         it 'returns error messages' do
           expect(JSON.parse(response.body)['errors']).to include(
-            "Name no puede estar en blanco", "Description no puede estar en blanco"
+            "La validación falló: Name no puede estar en blanco, Description no puede estar en blanco"
           )
         end
       end
@@ -67,6 +67,108 @@ RSpec.describe Api::V1::UnitsController, type: :controller do
 
       it 'returns error message' do
         expect(JSON.parse(response.body)['errors']).to include("Couldn't find Course with 'id'=0")
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    let(:course) { user.selected_course }
+    let!(:unit) { create(:unit, course: course, position: 2) }
+    let!(:unit1) { create(:unit, course: course, position: 1) }
+    let!(:unit3) { create(:unit, course: course, position: 3) }
+    let(:new_attributes) { { name: 'Updated Unit Name', description: 'Updated description' } }
+
+    context 'when user is authorized' do
+      context 'with valid params' do
+        before do
+          put :update, params: { course_id: course.id, id: unit.id, unit: new_attributes }
+        end
+
+        it 'updates the requested unit' do
+          unit.reload
+          expect(unit.name).to eq('Updated Unit Name')
+          expect(unit.description).to eq('Updated description')
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context 'when updating position' do
+        context 'moving unit to a higher position' do
+          before do
+            put :update, params: { course_id: course.id, id: unit.id, unit: { position: 3 } }
+          end
+
+          it 'updates the unit position' do
+            unit.reload
+            expect(unit.position).to eq(3)
+          end
+
+          it 'adjusts other units positions correctly' do
+            unit3.reload
+            expect(unit3.position).to eq(2)
+          end
+        end
+
+        context 'moving unit to a lower position' do
+          before do
+            put :update, params: { course_id: course.id, id: unit3.id, unit: { position: 1 } }
+          end
+
+          it 'updates the unit position' do
+            unit3.reload
+            expect(unit3.position).to eq(1)
+          end
+
+          it 'adjusts other units positions correctly' do
+            unit1.reload
+            expect(unit1.position).to eq(2)
+          end
+        end
+      end
+
+      context 'with invalid params' do
+        before do
+          put :update, params: { course_id: course.id, id: unit.id, unit: invalid_attributes }
+        end
+
+        it 'returns http unprocessable entity' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'returns error messages' do
+          expect(JSON.parse(response.body)['errors']).to include(
+            "La validación falló: Name no puede estar en blanco, Description no puede estar en blanco"
+          )
+        end
+      end
+    end
+
+    context 'when user is not authorized' do
+      let(:other_course) { create(:course) }
+      let(:other_unit) { create(:unit, course: other_course) }
+
+      it 'raises CanCan::AccessDenied' do
+        expect {
+          put :update, params: { course_id: other_course.id, id: other_unit.id, unit: new_attributes }
+        }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context 'when unit does not exist' do
+      before do
+        allow(controller).to receive(:authorize!).and_return(true)
+        put :update, params: { course_id: course.id, id: 0, unit: new_attributes }
+      end
+
+      it 'returns http not found' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns error message' do
+        expect(JSON.parse(response.body)['errors']).to include("Couldn't find Unit with 'id'=0 [WHERE \"units\".\"course_id\" = $1]")
       end
     end
   end

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Unit, type: :model do
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:position) }
 
-    it { should validate_numericality_of(:position).only_integer.is_greater_than_or_equal_to(0) }
+    it { should validate_numericality_of(:position).only_integer.is_greater_than_or_equal_to(1) }
 
     it 'validates uniqueness of position scoped to course_id' do
       existing_unit = create(:unit)


### PR DESCRIPTION
This pull request introduces an `update` action for the `UnitsController` to allow updating unit attributes, including the ability to reorder units within a course. It also includes necessary updates to policies, routes, and tests to support this new functionality.

### Controller Changes:
* Added an `update` action in `app/controllers/api/v1/units_controller.rb` to handle unit updates, including reordering units by adjusting their positions within a course. The logic ensures that other units' positions are updated accordingly when a unit's position changes. [[1]](diffhunk://#diff-faef7b3a885796cd5e63e4450c927ab98827a804085e68866762c1b3ad31fc91L6-R13) [[2]](diffhunk://#diff-faef7b3a885796cd5e63e4450c927ab98827a804085e68866762c1b3ad31fc91R24-R58)
* Updated `unit_params` to permit the `position` attribute.

### Policy Updates:
* Modified `units_policy` in `app/models/abilities/teacher_ability.rb` to grant teachers the `update` permission for units associated with their courses.

### Route and View Updates:
* Updated `config/routes.rb` to include the `update` action for units.
* Added a new JBuilder view file (`app/views/api/v1/units/update.jbuilder`) to render the updated unit as JSON.

### Tests:
* Added comprehensive tests for the `update` action in `spec/controllers/api/v1/units_controller_spec.rb`. These tests cover scenarios such as updating unit attributes, reordering units, handling invalid parameters, unauthorized access, and non-existent units.