### PR TITLE
[FQ-98] Export Preguntas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rails", "~> 8.0.2"
 gem "pg", "~> 1.5", ">= 1.5.9"
 gem "puma", ">= 5.0"
 gem "jbuilder", "~> 2.13"
+gem "csv", "~> 3.3", ">= 3.3.5"
 
 gem "devise", "~> 4.9", ">= 4.9.4"
 gem "devise_token_auth", "~> 1.2", ">= 1.2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
+    csv (3.3.5)
     database_cleaner (2.1.0)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.2.0)
@@ -400,6 +401,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   cancancan (~> 3.6, >= 3.6.1)
+  csv (~> 3.3, >= 3.3.5)
   database_cleaner (~> 2.1)
   debug
   devise (~> 4.9, >= 4.9.4)

--- a/app/models/abilities/teacher_ability.rb
+++ b/app/models/abilities/teacher_ability.rb
@@ -18,7 +18,7 @@ module Abilities
     private
 
     def courses_policy
-      @ability.can [ :read, :update, :reports ], Course, users: { id: @user.id }
+      @ability.can [ :read, :update, :reports, :export ], Course, users: { id: @user.id }
     end
 
     def units_policy

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -12,6 +12,7 @@ class Question < ActiveRecord::Base
 
   scope :reported, -> { where("score < 0") }
   scope :not_reported, -> { where("score >= 0") }
+  scope :generated, -> { where(generating: false) }
 
   def correct_option
     options.correct.first

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative "boot"
 
 require "rails/all"
+require "csv"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Register CSV as a valid MIME type
+Mime::Type.register "text/csv", :csv

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
       resources :courses, only: [ :show, :update ] do
         get :reports, on: :member
+        get :questions_csv, on: :member
         resources :units, only: [ :show, :create, :update ] do
           resources :topics, only: [ :create, :update, :destroy ]
         end


### PR DESCRIPTION
This pull request introduces functionality to export course questions in CSV format, along with supporting changes across controllers, models, routes, and tests. The most important changes include adding the `questions_csv` endpoint, implementing CSV generation logic in the `Course` model, and ensuring proper MIME type registration for CSV files.

### New functionality for exporting questions in CSV format:

* **Controller changes**: Added a new `questions_csv` action in `app/controllers/api/v1/courses_controller.rb` to handle CSV export requests. The action validates the format, authorizes access, and sends CSV data generated by the `Course` model.
* **Model changes**: Implemented the `questions_csv_data` method in `app/models/course.rb` to generate CSV data for course questions, including headers and filtering out reported or generating questions. Added new scopes in `app/models/question.rb` for filtering questions (`generated`, `reported`, and `not_reported`). [[1]](diffhunk://#diff-434c70e8f67701891105f1af973edd3f69d4cd17338275df30d1ed778a17c16dR48-R84) [[2]](diffhunk://#diff-6a70af3798f9540a6306905651b99064d092572fe825d23218f089ebfc70f86cR15)

### Supporting updates for CSV functionality:

* **Routes**: Added a new route for the `questions_csv` endpoint in `config/routes.rb` under the `courses` resource.
* **MIME type registration**: Registered `text/csv` as a valid MIME type in `config/initializers/mime_types.rb`.
* **Gem dependency**: Added the `csv` gem to the `Gemfile` and required it in `config/application.rb` for CSV handling. [[1]](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR7) [[2]](diffhunk://#diff-c1fd91cb1911a0512578b99f657554526f3e1421decdb9e908712beab57e10f9R4)

### Tests for CSV functionality:

* **Controller tests**: Added specs in `spec/controllers/api/v1/courses_controller_spec.rb` to test the `questions_csv` endpoint, including format validation, authorization, and CSV content.
* **Model tests**: Added specs in `spec/models/course_spec.rb` to verify the `questions_csv_data` method, ensuring proper headers, inclusion/exclusion of questions, and filtering logic.